### PR TITLE
xthreejs is optional, speeds up usage with cling

### DIFF
--- a/include/xvolume/xscatter.hpp
+++ b/include/xvolume/xscatter.hpp
@@ -15,7 +15,9 @@
 
 #include "xtl/xoptional.hpp"
 
+#ifdef XTHREE_SHADER_MATERIAL_HPP
 #include "xthreejs/materials/xshader_material_autogen.hpp"
+#endif
 
 #include "xwidgets/xmaterialize.hpp"
 #include "xwidgets/xobject.hpp"
@@ -62,9 +64,10 @@ namespace xvl
         // Note: this is a Union in ipywidgets
         XPROPERTY(std::string, derived_type, texture);
 
+        #ifdef XTHREE_SHADER_MATERIAL_HPP
         XPROPERTY(xthree::shader_material, derived_type, material);
         XPROPERTY(xthree::shader_material, derived_type, line_material);
-
+        #endif
     protected:
 
         xscatter();
@@ -149,8 +152,10 @@ namespace xvl
         this->_model_module_version() = XIPYVOLUME_VERSION;
         this->_view_module_version() = XIPYVOLUME_VERSION;
 
+        #ifdef XTHREE_SHADER_MATERIAL_HPP
         this->material() = xthree::shader_material();
         this->line_material() = xthree::shader_material();
+        #endif
     }
 
     template <class D>

--- a/include/xvolume/xvolume_figure.hpp
+++ b/include/xvolume/xvolume_figure.hpp
@@ -19,8 +19,12 @@
 #include "xtl/xoptional.hpp"
 
 // xthreejs stuff
+#ifdef XTHREE_CAMERA_HPP
 #include "xthreejs/cameras/xperspective_camera_autogen.hpp"
+#endif
+#ifdef XTHREE_SCENE_HPP
 #include "xthreejs/scenes/xscene_autogen.hpp"
+#endif
 
 #include "xwidgets/xeither.hpp"
 #include "xwidgets/xwidget.hpp"
@@ -79,8 +83,13 @@ namespace xvl
 
         XPROPERTY(camera_position_type, derived_type, camera_center);
 
+        #ifdef XTHREE_CAMERA_HPP
         XPROPERTY(xthree::perspective_camera, derived_type, camera);
+        #endif
+
+        #ifdef XTHREE_SCENE_HPP
         XPROPERTY(xthree::scene, derived_type, scene);
+        #endif
 
         XPROPERTY(int, derived_type, width, 500);
         XPROPERTY(int, derived_type, height, 400);
@@ -162,13 +171,17 @@ namespace xvl
         this->xlim() = std::array<double, 2>{0, 1};
         this->ylim() = std::array<double, 2>{0, 1};
         this->zlim() = std::array<double, 2>{0, 1};
+        #ifdef XTHREE_CAMERA_HPP
         this->camera() = xthree::perspective_camera_generator()
             .fov(46)
             .position({0, 0, 2})
             .finalize();
+        #endif
+        #ifdef XTHREE_SCENE_HPP
         this->scene() = xthree::scene_generator()
             .background(xtl::missing<xw::html_color>())
             .finalize();
+        #endif
     }
 
     template <class D>


### PR DESCRIPTION
If you need camera or material access, just include the xthreejs headers first.